### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     if: github.event_name == 'workflow_dispatch' || github.event.repository.private != true
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/BrunoO/FindHelper/security/code-scanning/2](https://github.com/BrunoO/FindHelper/security/code-scanning/2)

To fix the problem, we should explicitly set minimal GITHUB_TOKEN permissions for the `build` job. Since this job only checks out code, builds, runs tests, and uploads artifacts, it only needs read access to repository contents, and does not need write access to releases, issues, or pull requests.

The best fix is to add a `permissions` block under the `build` job that sets `contents: read`. This ensures the build job’s token cannot modify repository contents even if the repo/org default is `contents: write`. We do not need to change the existing `release` job permissions, as it legitimately requires `contents: write` to publish releases. Concretely, in `.github/workflows/build.yml`, insert:

```yaml
    permissions:
      contents: read
```

immediately under the `build:` job header (after `build:` and before or after the `if:` line; both are valid, but we’ll place it just after `build:` for clarity). No new imports or methods are required; this is a purely declarative change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
