### PR TITLE
Change Ubuntu version in build workflow to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
             artifact_path: build/FindHelper.app
             package_name: FindHelper-macOS.zip
             build_with_boost: true
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             # 20.04 → glibc 2.31; keeps Linux artifact runnable on older distros (24.04 would require glibc 2.39)
             config: Release
             artifact_name: FindHelper-Linux-x64


### PR DESCRIPTION
Updated the build workflow to use Ubuntu 22.04 instead of 20.04 for Linux builds.

## What does this change?

<!-- Brief description of what this PR does and why. -->

## How was it tested?

<!-- Describe how you verified the change works and doesn't break anything. -->
<!-- e.g. "Built and ran on macOS, ran tests with scripts/build_tests_macos.sh" -->

## Checklist

- [ ] Builds without errors on the target platform(s)
- [ ] All tests pass (`ctest --test-dir build --output-on-failure`)
- [ ] clang-tidy is clean (pre-commit hook passes)
- [ ] Follows naming conventions in [AGENTS.md](AGENTS.md)
- [ ] No new `#ifdef` blocks that could be unified across platforms
