### PR TITLE
Update Linux target to Ubuntu 22.04 in GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             package_name: FindHelper-macOS.zip
             build_with_boost: true
           - os: ubuntu-22.04
-            # 20.04 → glibc 2.31; keeps Linux artifact runnable on older distros (24.04 would require glibc 2.39)
+            # 22.04 → glibc 2.35; keeps Linux artifact runnable on older distros (24.04 would require glibc 2.39)
             config: Release
             artifact_name: FindHelper-Linux-x64
             artifact_path: build/FindHelper
@@ -69,7 +69,7 @@ jobs:
           .\vcpkg\vcpkg install boost-headers boost-unordered boost-regex boost-lockfree
 
       - name: Install Linux dependencies
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           PACKAGES="build-essential cmake pkg-config libglfw3-dev libgl1-mesa-dev libglu1-mesa-dev libcurl4-openssl-dev libfontconfig1-dev libx11-dev libxss-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libwayland-bin"
           if [ "${{ env.BUILD_WITH_BOOST }}" = "true" ]; then PACKAGES="$PACKAGES libboost-dev"; fi
@@ -95,7 +95,7 @@ jobs:
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON $EXTRA
 
       - name: Configure (Linux)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           EXTRA=""; [ "${{ env.BUILD_WITH_BOOST }}" = "true" ] && EXTRA="-DFAST_LIBS_BOOST=ON"
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON $EXTRA
@@ -109,7 +109,7 @@ jobs:
         run: cmake --build build --config ${{ matrix.config }}
 
       - name: Build (Linux)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: cmake --build build
 
       - name: Run tests (Windows)
@@ -121,7 +121,7 @@ jobs:
         run: ctest --test-dir build --output-on-failure
 
       - name: Run tests (Linux)
-        if: matrix.os == 'ubuntu-20.04' && github.event.repository.private == true
+        if: matrix.os == 'ubuntu-22.04' && github.event.repository.private == true
         run: ctest --test-dir build --output-on-failure
 
       - name: Package (Windows)
@@ -139,7 +139,7 @@ jobs:
           zip -r ${{ matrix.package_name }} ${{ matrix.artifact_path }}
 
       - name: Package (Linux)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: tar -czf ${{ matrix.package_name }} -C build FindHelper
 
       - name: Upload artifact


### PR DESCRIPTION
I have updated the GitHub workflow file `.github/workflows/build.yml` to target Ubuntu 22.04 for Linux builds. This involved replacing all occurrences of `20.04` with `22.04` in step conditions and updating the technical comment about `glibc` versions. After verifying the YAML syntax and the changes, I merged the updated branch into `main` as requested.

---
*PR created automatically by Jules for task [12467298441792247492](https://jules.google.com/task/12467298441792247492) started by @BrunoO*